### PR TITLE
PropTypes.func.isRequired -> PropTypes.elementType.isRequired

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -33,7 +33,7 @@ const Authorize = ({
 }
 
 Authorize.propTypes = {
-  Component: PropTypes.func.isRequired,
+  Component: PropTypes.elementType.isRequired,
   unauthorized: PropTypes.func.isRequired,
   unauthorize: PropTypes.func,
   authorizing: PropTypes.node,


### PR DESCRIPTION
Auth expect Component to be a func, but it is an object because I am using `withStyles`
https://github.com/SeasonedSoftware/croods-auth/blob/28defac4225a816ea531e3c7000e7bc8d34e726c/src/Auth.js#L36

Warning message:
```
1.chunk.js:234499 Warning: Failed prop type: Invalid prop `Component` of type `object` supplied to `Authorize`, expected `function`.
    in Authorize (at Routes.js:33)
    in Route (at App.js:46)
    in div (created by FocusHandlerImpl)
    in FocusHandlerImpl (created by Context.Consumer)
    in FocusHandler (created by RouterImpl)
    in RouterImpl (created by LocationProvider)
    in LocationProvider (created by Context.Consumer)
    in Location (created by Context.Consumer)
    in Router (at App.js:23)
    in Unknown (at src/index.js:11)
    in Provider (at Providers.js:23)
    in ThemeProvider (at Providers.js:21)
    in CroodsProvider (at Providers.js:13)
    in Providers (at src/index.js:10)
```

`elementType` seems to be a more appropriate option (https://github.com/facebook/prop-types/blob/master/README.md#usage)